### PR TITLE
Also apply the Oracle Cloud checksum workaround to UpCloud Object Storage

### DIFF
--- a/s3.go
+++ b/s3.go
@@ -169,9 +169,12 @@ func (s *s3Storage) getClient(l logging.Logger) *s3.Client {
 
 		o.UsePathStyle = s.conf.ForcePathStyle
 
-		// switch to md5 checksum for oracle cloud
+		// switch to md5 checksum for providers that don't support AWS SDK v2
+		// flexible checksums (e.g. Oracle Cloud, UpCloud)
 		if s.conf.Endpoint != "" {
-			if parsed, err := url.Parse(s.conf.Endpoint); err == nil && strings.HasSuffix(parsed.Host, "oraclecloud.com") {
+			if parsed, err := url.Parse(s.conf.Endpoint); err == nil &&
+				(strings.HasSuffix(parsed.Host, "oraclecloud.com") ||
+					strings.HasSuffix(parsed.Host, "upcloudobjects.com")) {
 				o.APIOptions = append(o.APIOptions, func(stack *middleware.Stack) error {
 					stack.Initialize.Remove("AWSChecksum:SetupInputContext")
 					stack.Build.Remove("AWSChecksum:RequestMetricsTracking")


### PR DESCRIPTION
**Problem**
AWS SDK v2 enabled flexible checksums by default in early 2025, adding a CRC32 trailer to every PutObject. UpCloud Object Storage doesn't yet support this flow and rejects uploads with XAmzContentSHA256Mismatch — the same failure mode Oracle Cloud exhibited, which this file already handles (lines 172–183).
Reproducible with the plain AWS CLI against UpCloud:

aws s3 cp ... --endpoint-url https://<account>.upcloudobjects.com ... → fails with XAmzContentSHA256Mismatch
Same command with AWS_REQUEST_CHECKSUM_CALCULATION=when_required → succeeds

So it's a general SDK-v2-defaults-vs-provider incompatibility, not specific to LiveKit.

**Fix**
Extend the existing host-suffix check to also match upcloudobjects.com. Same middleware swap, same behavior — just one more provider on the allow-list.

```
-		// switch to md5 checksum for oracle cloud
+		// switch to md5 checksum for providers that don't support AWS SDK v2
+		// flexible checksums (e.g. Oracle Cloud, UpCloud)
 		if s.conf.Endpoint != "" {
-			if parsed, err := url.Parse(s.conf.Endpoint); err == nil && strings.HasSuffix(parsed.Host, "oraclecloud.com") {
+			if parsed, err := url.Parse(s.conf.Endpoint); err == nil &&
+				(strings.HasSuffix(parsed.Host, "oraclecloud.com") ||
+					strings.HasSuffix(parsed.Host, "upcloudobjects.com")) {
```

**Verification**
Wrote a small reproduction using the same SDK versions this module pins (aws-sdk-go-v2 v1.36.5, service/s3 v1.81.0). Two test cases against the same UpCloud bucket:

Default AWS SDK v2 client → PutObject fails with XAmzContentSHA256Mismatch
Same client with this module's Oracle middleware swap applied → PutObject succeeds

go build ./... and go vet ./... both pass cleanly with the change applied.
Backwards compatibility
No behavior change for any existing user. Oracle Cloud users continue working unchanged. Only new effect is that uploads to *.upcloudobjects.com endpoints now succeed instead of failing.
Context
Happy to do a follow-up PR exposing a general disable_flexible_checksums config field + proto field if you'd prefer a future-proof knob for the next provider to hit this — but this narrower change unblocks UpCloud users today with minimal surface area.