### PR TITLE
Fix multipart uploads on S3-compatible providers that lack streaming-trailer support

### DIFF
--- a/s3.go
+++ b/s3.go
@@ -226,7 +226,25 @@ func (s *s3Storage) upload(reader io.Reader, storagePath, contentType string) (s
 		input.ContentDisposition = &contentDisposition
 	}
 
-	if _, err := manager.NewUploader(client).Upload(context.Background(), input); err != nil {
+	uploader := manager.NewUploader(client, func(u *manager.Uploader) {
+		if s.conf.Endpoint != "" {
+			// S3-compatible providers commonly don't support AWS SDK v2's
+			// chunked transfer encoding (STREAMING-UNSIGNED-PAYLOAD-TRAILER)
+			// that the uploader uses for UploadPart, and reject every part
+			// with XAmzContentSHA256Mismatch (see UpCloud, older Ceph RGW,
+			// Oracle Cloud Storage, etc.). Routing through a single
+			// PutObject — which uses classic SigV4 with a pre-computed body
+			// hash — works across all S3-compatible backends. Raising
+			// PartSize to the 5 GiB single-PutObject limit makes the
+			// uploader take that path for any body that fits in one part.
+			//
+			// Bodies above 5 GiB will still attempt multipart and fail on
+			// affected backends; egress recordings are not expected to
+			// exceed this in practice.
+			u.PartSize = 5 * 1024 * 1024 * 1024
+		}
+	})
+	if _, err := uploader.Upload(context.Background(), input); err != nil {
 		l.WriteLogs()
 		return "", err
 	}


### PR DESCRIPTION
## Summary

Follow-up to @frostbyte73 's #22. That PR set `RequestChecksumCalculation = WhenRequired` on the `s3.Client` config when `Endpoint != ""`, which fixes direct `client.PutObject` calls — but `manager.Uploader`'s per-part flow is unaffected. Every `UploadPart` still goes out as `STREAMING-UNSIGNED-PAYLOAD-TRAILER`, which UpCloud, older Ceph RGW, Oracle Cloud Storage, and similar S3-compatible backends reject with `XAmzContentSHA256Mismatch`.

This PR raises the uploader's `PartSize` to the 5 GiB single-PutObject limit when `Endpoint != ""`, which causes the manager to route any body that fits in one part through a single `PutObject` call (classic SigV4 with pre-computed body hash). That path is the original S3 API and works across all S3-compatible backends.

## Why this approach

The minimum-diff fix that matches the existing pattern. Alternatives considered:

- **Manual `CreateMultipartUpload` + `UploadPart` with `bytes.Reader` bodies.** Strictly more correct because it also fixes files > 5 GiB on these backends, but adds ~80–150 lines of multipart bookkeeping and gives up the existing retry/concurrency story from `manager.Uploader`. Worth doing if support for >5 GiB files on non-AWS endpoints is wanted; for typical recording workloads it isn't.
- **Setting `ChecksumAlgorithm` on the `PutObjectInput`** (CRC32 / CRC32C / SHA1 / SHA256). Tested all five; none change the behavior — the failure isn't about which algorithm, it's about the streaming-trailer flow itself.

## Reproduction

Standalone Go program against `livekit/storage` at the PR #22 merge commit, uploading random payloads to UpCloud:

```
[FAIL] manager.Uploader, DEFAULT checksum   → UploadPart 400, XAmzContentSHA256Mismatch
[FAIL] manager.Uploader, CRC32              → UploadPart 400, XAmzContentSHA256Mismatch
[FAIL] manager.Uploader, CRC32C             → UploadPart 400, XAmzContentSHA256Mismatch
[FAIL] manager.Uploader, SHA1               → UploadPart 400, XAmzContentSHA256Mismatch
[FAIL] manager.Uploader, SHA256             → UploadPart 400, XAmzContentSHA256Mismatch
[ OK ] raw client.PutObject (8 MB)          → 250 ms
[ OK ] manager.Uploader, PartSize=5 GiB (8 MB) → 423 ms
```

With this PR applied (same as the last line above), 8 MB uploads through the existing `(*s3Storage).UploadFile` code path succeed against UpCloud.

## Backwards compatibility

- **AWS S3** (`Endpoint == ""`): no behavior change. Uploader still uses default 5 MB `PartSize` and the normal multipart flow.
- **S3-compatible providers** (`Endpoint != ""`): files ≤ 5 GiB now take the single-PutObject path, which all of them already accept. Files > 5 GiB still attempt multipart and will continue to fail on backends without streaming-trailer support — same behavior as today for that size range. In practice egress recordings don't exceed 5 GiB.

## Limitation noted

For files > 5 GiB on backends without `STREAMING-UNSIGNED-PAYLOAD-TRAILER` support, manual multipart with per-part `bytes.Reader` bodies (so the SDK pre-computes per-part SHA-256 and uses classic signing) is the long-term answer. Out of scope here; happy to follow up with a second PR if there's demand.